### PR TITLE
Replace generic error with specific loginError and signupError

### DIFF
--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -153,7 +153,7 @@ export default function LoginForm({ onLogin }: LoginFormProps) {
     {
       icon: Shield,
       title: "Seguro & Acessível",
-      description: "Proteção de dados e interface totalmente acess��vel",
+      description: "Proteção de dados e interface totalmente acessível",
     },
   ];
 
@@ -369,10 +369,10 @@ export default function LoginForm({ onLogin }: LoginFormProps) {
 
                 <TabsContent value="signup">
                   <form onSubmit={handleSignup} className="space-y-4">
-                    {error && (
+                    {signupError && (
                       <Alert variant="destructive">
                         <AlertCircle className="h-4 w-4" />
-                        <AlertDescription>{error}</AlertDescription>
+                        <AlertDescription>{signupError}</AlertDescription>
                       </Alert>
                     )}
 

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -153,7 +153,7 @@ export default function LoginForm({ onLogin }: LoginFormProps) {
     {
       icon: Shield,
       title: "Seguro & Acessível",
-      description: "Proteção de dados e interface totalmente acessível",
+      description: "Proteção de dados e interface totalmente acess��vel",
     },
   ];
 
@@ -273,10 +273,10 @@ export default function LoginForm({ onLogin }: LoginFormProps) {
 
                 <TabsContent value="login">
                   <form onSubmit={handleLogin} className="space-y-4">
-                    {error && (
+                    {loginError && (
                       <Alert variant="destructive">
                         <AlertCircle className="h-4 w-4" />
-                        <AlertDescription>{error}</AlertDescription>
+                        <AlertDescription>{loginError}</AlertDescription>
                       </Alert>
                     )}
 


### PR DESCRIPTION
Updates error handling in LoginForm component to use more specific error variables.

Changes:
- Replace `error` with `loginError` in login tab error display
- Replace `error` with `signupError` in signup tab error display

This provides better separation between login and signup error states.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/33af6b7a978d4aa385bcec2b6edb3655/swoosh-works)

👀 [Preview Link](https://33af6b7a978d4aa385bcec2b6edb3655-swoosh-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>33af6b7a978d4aa385bcec2b6edb3655</projectId>-->
<!--<branchName>swoosh-works</branchName>-->